### PR TITLE
Add axolotol as protected

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,3 +22,4 @@ pets:
  - LLAMA
  - TRADER_LLAMA
  - IRON_GOLEM
+ - AXOLOTOL


### PR DESCRIPTION
Our new swimmy pals need to be protected too! 


While this plugin is marked as supported in 1.15, it is running perfectly fine on git-Purpur-1523 (Git: c672eea on HEAD)